### PR TITLE
Support user info for logged-out users

### DIFF
--- a/old-src/endpoints/v1.es6.js
+++ b/old-src/endpoints/v1.es6.js
@@ -1036,6 +1036,8 @@ class APIv1Endpoint {
 
         if (options.user === 'me') { // current oauth doesn't return user id
           uri += 'api/v1/me';
+        } else if (options.loggedOut) {
+          uri += 'api/me.json';
         } else {
           uri += 'user/' + options.user + '/about.json';
         }
@@ -1064,8 +1066,14 @@ class APIv1Endpoint {
 
       formatBody: function(options) {
         return function(body) {
+          // Make sure we have a name to key off for the case of logged-out
+          // user information.
+          const data = {
+            name: '',
+            ...(body.data || body)
+          };
           if (body) {
-            return new Account(body.data || body).toJSON();
+            return new Account(data).toJSON();
           }
         };
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@r/api-client",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "node and browser reddit api library",
   "main": "index.es6.js",
   "scripts": {


### PR DESCRIPTION
We need to know the assigned experiment variants for logged-in and
logged-out users. The API will expose the data in compatible ways on
both /api/v1/me and /api/me.json, the latter for logged-out users.