### PR TITLE
Refactor APIRequestUtils straw man

### DIFF
--- a/apiBase/APIRequestUtils.es6.js
+++ b/apiBase/APIRequestUtils.es6.js
@@ -4,14 +4,6 @@ import ValidationError from './errors/ValidationError';
 import NoModelError from './errors/NoModelError';
 import APIResponse from './APIResponse';
 
-import Events from './Events';
-
-const EventEmitterShim = {
-  emit: () => {},
-  on: () => {},
-  off: () => {},
-};
-
 const DefaultOptions = {
   userAgent: 'snoodev3',
   origin: 'https://www.reddit.com',
@@ -19,81 +11,48 @@ const DefaultOptions = {
   env: 'develop',
   token: '',
   timeout: 5000,
-  eventEmitter: EventEmitterShim,
 };
 
-export const makeOptions = (overrides={}) => {
-  return {
-    ...DefaultOptions,
-    ...overrides,
-  };
+export const makeOptions = (overrides={}) => ({ ...DefaultOptions, ...overrides });
+
+const requestHeaders = ({ token, defaultHeaders={} }) => {
+  const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
+  return { ...defaultHeaders, ...authHeaders };
 };
 
-const getEmitter = (apiOptions) => {
-  return (apiOptions.eventEmitter || EventEmitterShim);
-};
+export const rawSend = (apiOptions, method, path, data, kind) => {
+  const { origin, appName, env } = apiOptions;
+  const _path = path.startsWith("/") ? path : `/${path}`;
+  const url = `${origin}${_path}`;
 
-const requestAuthHeader = (apiOptions) => {
-  const token = apiOptions.token;
-  if (!token) { return {}; }
-  return { Authorization: `Bearer ${token}` };
-};
-
-const requestHeaders = (apiOptions) => {
-  const authHeaders = requestAuthHeader(apiOptions);
-  return {
-    ...(apiOptions.defaultHeaders || {}),
-    ...authHeaders,
-  };
-};
-
-const requestPath = (apiOptions, path) => {
-  let slash = '/';
-
-  if (path.indexOf('/') === 0) {
-    slash = '';
-  }
-
-  return `${apiOptions.origin}${slash}${path}`;
-};
-
-const appParameter = (apiOptions) => {
-  return `${apiOptions.appName}-${apiOptions.env}`;
-};
-
-export const rawSend = (apiOptions, method, path, data, kind, cb) => {
-  const origin = apiOptions.origin;
-  const url = requestPath(apiOptions, path);
-
-  const fakeReq = {
-    origin,
-    path,
-    url,
-    method,
-    query: { ...data},
-  };
-
-  getEmitter(apiOptions).emit(Events.request, fakeReq);
   let s = superagent[method](url);
   s.set(requestHeaders(apiOptions));
 
-  data.app = appParameter(apiOptions);
+  const _data = { ...data, app: `${appName}-${env}` };
 
   if (kind === 'form') {
     s.type('form');
-    s.send(data);
+    s.send(_data);
   } else {
-    s.query(data);
+    s.query(_data);
 
     if (s.redirects) {
       s.redirects(0);
     }
   }
 
-  s.end((err, res) => {
-    // handle super agent inconsistencies
-    const req = res ? res.request : fakeReq;
-    cb(err, res, req);
+  return new Promise((resolve, reject) => {
+    s.end((err, res) => {
+      // handle super agent inconsistencies
+      const fakeReq = { origin, path: _path, url, method, query: { ...data} };
+      const req = res ? res.request || res.req : fakeReq;
+
+      if (err) {
+        reject(err, req);
+      } else {
+        resolve(res, req);
+      }
+    });
   });
 };
 
@@ -105,72 +64,30 @@ export const validateData = (data, method, apiName, validator) => {
 export const save = (apiOptions, method, path, data, parseBody, parseMeta) => {
   if (!(apiOptions && method && path && data)) { throw new NoModelError(); }
 
-  return new Promise((resolve, reject) => {
-    rawSend(apiOptions, method, path, data, 'form', (err, res, req) => {
-      handle(apiOptions, resolve, reject, err, res, req, data, method, parseBody, parseMeta);
-    });
-  });
+  return rawSend(apiOptions, method, path, data, 'form')
+    .then((res, req) => makeApiResponse(res, req, method, query, parseBody, parseMeta))
+    .catch((err, req) => console.trace(err));
 };
 
-export const runQuery = (apiOptions, method, path, query, rawQuery, parseBody, parseMeta) => {
-  if (!(apiOptions && method && path && query && rawQuery)) { throw new NoModelError(); }
+export const runQuery = (apiOptions, method, path, query, parseBody, parseMeta) => {
+  if (!(apiOptions && method && path && query)) {
+    throw new NoModelError();     // TODO: does this error make sense?
+  }
 
-  if (method === 'get') {
+  if (method.toLowerCase() === 'get') {
     query.raw_json = 1;
   }
 
-  return new Promise((resolve, reject) => {
-    rawSend(apiOptions, method, path, query, 'query', (err, res, req) => {
-      handle(apiOptions, resolve, reject, err, res, req, rawQuery, method, parseBody, parseMeta);
-    });
-  });
-};
-
-const normalizeRequest = (res, req) => {
-  if (res && !req) {
-    return res.request || res.req;
-  }
-
-  return req;
-};
-
-const handleRequestIfFailed = (apiOptions, err, res, req, reject) => {
-  if (!(err || (res && !res.ok))) { return; }
-
-  getEmitter(apiOptions).emit(Events.error, err, req);
-  const errorHandler = apiOptions.defaultErrorHandler || reject;
-  errorHandler(err || 500);
-  return true;
-};
-
-const handle = (apiOptions, resolve, reject, err, res, req, query, method,
-    parseBody, parseMeta) => {
-
-  req = normalizeRequest(res, req);
-
-  if (handleRequestIfFailed(apiOptions, err, res, req, reject)) {
-    return;
-  }
-
-  getEmitter(apiOptions).emit(Events.response, req, res);
-
-  const apiResponse = tryParseResponse(reject, res, req, method, query, parseBody, parseMeta);
-
-  getEmitter(apiOptions).emit(Events.result, apiResponse);
-  resolve(apiResponse);
-};
-
-const tryParseResponse = (reject, res, req, method, query, parseBody, parseMeta) => {
-  try {
-    return makeApiResponse(res, req, method, query, parseBody, parseMeta);
-  } catch (e) {
-    console.trace(e);
-    reject(e);
-  }
+  return rawSend(apiOptions, method, path, query, 'query')
+    .then((res, req) => makeApiResponse(res, req, method, query, parseBody, parseMeta))
+    .catch((err, req) => console.trace(err));
 };
 
 const makeApiResponse = (res, req, method, query, parseBody, parseMeta) => {
-  if (!parseBody) { return res.body; }
+  if (!parseBody) {
+    return res.body;
+  }
+
   const meta = parseMeta ? parseMeta(res, req, method) : res.headers;
   const apiResponse = new APIResponse(meta, query);
   const start = Date.now();


### PR DESCRIPTION
This is about 75 lines shorter and I think utilizes promises in a more correct manner. We're now minimizing the amount of callback passing and the number of arguments since these are available in the scope of the promise's callbacks. This makes for cleaner and easier to understand code. This is just a straw man and has not been tested but I want to get your thoughts before I dive into a full refactor.

Some more notes on this:

1. I removed EventEmitter because its utility wasn't obvious to me. It can be added back in if you feel strongly.
2. I couldn't figure out where defaultErrorHandler was supposed to be defined so I removed it. Probably simple to add back as well.
3. One problem with this approach is that it conflates the idea of an http error and an exception. For now, I acknowledge that and will clean it up but I wanted to show you what I think is a more correct and cleaner approach to promises before I got into the nitty and gritty details.

:eyeglasses: @schwers 