### PR TITLE
Pass along loids generated by the api

### DIFF
--- a/old-src/endpoints/v1.es6.js
+++ b/old-src/endpoints/v1.es6.js
@@ -1070,7 +1070,11 @@ class APIv1Endpoint {
           // user information.
           const data = {
             name: '',
-            ...(body.data || body)
+            ...(body.data || body),
+            loid: body.loid,
+            loid_created: typeof body.loid_created === 'number'
+              ? new Date(body.loid_created).toISOString()
+              : body.loid_created,
           };
           if (body) {
             return new Account(data).toJSON();


### PR DESCRIPTION
Calls to /api/me return loids in the json response. This patch includes
those in the response body.

:eyeglasses: @schwers || @phil303 