### PR TITLE
Remove trailing slash in wiki api fetching

### DIFF
--- a/old-src/endpoints/v1.es6.js
+++ b/old-src/endpoints/v1.es6.js
@@ -1478,10 +1478,15 @@ class APIv1Endpoint {
     return bindAll({
       buildOptions: function(options) {
         let uri = options.origin;
+
+        // Chop off trailing slash if there is one
+        let path = options.path;
+        path = path.endsWith('/') ? path.slice(0, -1) : path;
+
         if (options.subreddit) {
-          uri += `/r/${options.subreddit}/wiki/${options.path}.json`;
+          uri += `/r/${options.subreddit}/wiki/${path}.json`;
         } else {
-          uri += `/wiki/${options.path}.json`;
+          uri += `/wiki/${path}.json`;
         }
 
         return { uri, options };


### PR DESCRIPTION
Stuff like /r/foobar/wiki/.json doesn't work and
ends up breaking links and SEO.

👓  @schwers @nramadas 