### PR TITLE
remove response parsing timing from log

### DIFF
--- a/apiBase/APIRequestUtils.es6.js
+++ b/apiBase/APIRequestUtils.es6.js
@@ -200,9 +200,6 @@ const makeApiResponse = (res, req, method, query, parseBody, parseMeta) => {
   if (!parseBody) { return res.body; }
   const meta = parseMeta ? parseMeta(res, req, method) : res.headers;
   const apiResponse = new APIResponse(res, meta, query);
-  const start = Date.now();
   parseBody(res, apiResponse, req, method);
-  const end = Date.now();
-  console.log(`response parsing took ${end - start}`);
   return apiResponse;
 };


### PR DESCRIPTION
I don't think anyone is actively using it and it's just white noise/cluttering up the logs.

:eyeglasses: @nramadas @schwers 