### PR TITLE
Fix bad export statements

### DIFF
--- a/src/apiBase/APIRequestUtils.es6.js
+++ b/src/apiBase/APIRequestUtils.es6.js
@@ -1,7 +1,7 @@
 import superagent from 'superagent';
 
 import Events from './Events';
-import APIResponse from './APIResponse';
+import { APIResponse } from './APIResponse';
 import NoModelError from './errors/NoModelError';
 import ResponseError from './errors/ResponseError';
 import ValidationError from './errors/ValidationError';

--- a/src/apiBase/APIResponse.es6.js
+++ b/src/apiBase/APIResponse.es6.js
@@ -85,7 +85,7 @@ export class APIResponseBase {
   appendResponse() { throw new Error('Not implemented in base class'); }
 }
 
-export default class APIResponse extends APIResponseBase {
+export class APIResponse extends APIResponseBase {
   constructor(response, meta={}, query={}) {
     super();
     this.request = response.req;

--- a/src/apiBase/apiRequest.js
+++ b/src/apiBase/apiRequest.js
@@ -1,6 +1,6 @@
 import superagent from 'superagent';
 
-import APIResponse from './APIResponse';
+import { APIResponse } from './APIResponse';
 import ResponseError from './errors/ResponseError';
 
 

--- a/src/collections/HiddenPostsAndComments.es6.js
+++ b/src/collections/HiddenPostsAndComments.es6.js
@@ -1,6 +1,6 @@
 import SavedPostsAndComments from './SavedPostsAndComments';
 import HiddenEndpoint from '../apis/HiddenEndpoint';
 
-export class HiddenPostsAndComments extends SavedPostsAndComments {
+export default class HiddenPostsAndComments extends SavedPostsAndComments {
   static endpoint = HiddenEndpoint;
 }


### PR DESCRIPTION
Problem:
This seems to have been unearthed when webpack 2 got updated. Things
that were not default exported were being imported as such.

Fix:
For ApiResponse, make it a non-default import and adjust all imports
accordingly. For the HiddenPostsAndComments collection, make it the
default. This clears up the warnings in the build step.

:eyeglasses: @nramadas || @uzi