### PR TITLE
Fix babel error with super and writing readonly props

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "superagent": "1.x"
   },
   "devDependencies": {
-    "@r/build": "~0.10.0",
+    "@r/build": "~0.10.1",
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-plugin-syntax-trailing-function-commas": "^6.8.0",

--- a/src/apiBase/errors/FakeError.es6.js
+++ b/src/apiBase/errors/FakeError.es6.js
@@ -1,3 +1,5 @@
+import omit from 'lodash/omit';
+
 export default class FakeError {
   constructor (message) {
     Object.defineProperty(this, 'message', { value: message });
@@ -7,5 +9,20 @@ export default class FakeError {
     } else {
       Object.defineProperty(this, 'stack', { value: (new Error()).stack });
     }
+  }
+
+  /**
+  * Use this when you want to merge properties from an object onto
+  * an instance of FakeError. In other FakeError subclasses we used to
+  * write things like `Object.assign(fakeErrorInstance, errorObject)`.
+  * This code breaks because `errorObject`, an instnace of the Error class,
+  * can have a property called `message` or `stack` that we assign
+  * as read-only properties in the FakeError constructor.
+  *
+  * @param {Object} - the object we want to copy properties from
+  * @returns {undefined} - used for the side-effect of copying key/values from input
+  */
+  safeAssignProps(obj) {
+    Object.assign(this, omit(obj, ['message', 'stack']));
   }
 }

--- a/src/apiBase/errors/NoModelError.js
+++ b/src/apiBase/errors/NoModelError.js
@@ -2,10 +2,9 @@ import FakeError from './FakeError';
 
 export default class NoModelError extends FakeError {
   constructor (endpoint) {
-    super(endpoint);
+    super(`No model given for api endpoint ${endpoint}`);
 
     this.name = 'NoModelError';
-    this.message = 'No model given for api endpoint ' + endpoint;
     this.status = 400;
   }
 }

--- a/src/apiBase/errors/NotImplementedError.js
+++ b/src/apiBase/errors/NotImplementedError.js
@@ -2,10 +2,9 @@ import FakeError from './FakeError';
 
 export default class NotImplementedError extends FakeError {
   constructor (method, endpoint) {
-    super(method, endpoint);
+    super(`Method ${method} not implemented for api endpoint ${endpoint}`);
 
     this.name = 'NotImplementedError';
-    this.message = `Method ${method} not implemented for api endpoint ${endpoint}`;
     this.status = 405;
   }
 }

--- a/src/apiBase/errors/ResponseError.js
+++ b/src/apiBase/errors/ResponseError.js
@@ -3,7 +3,7 @@ import FakeError from './FakeError';
 export class DisconnectedError extends FakeError {
   constructor(error, url) {
     super(`URL ${url} not reachable. You are probably disconnected from the internet.`);
-    Object.assign(this, error);
+    this.safeAssignProps(error);
   }
 }
 
@@ -18,15 +18,25 @@ export default class ResponseError extends FakeError {
     if (!error) { throw new Error('No error passed to ResponseError'); }
     if (!url) { throw new Error('No url passed to ResponseError'); }
 
+    // HACK: technically, we should be able to skip right to the check for
+    // `if (error.code && error.syscall) { ... }`, but there's a bug in babel
+    // preventing us from doing so. Babel wants to make sure `super` is called
+    // before we exit this constructor. This check is technically unneeded, because
+    // we're returning a new instance of a separate class -- and aborting init
+    // of this class. To workaround this, call super ahead of time
+    // so babel's check passes.
+    //
+    // NOTE: If you're looking through compiled code, this fixes a bug where
+    // babel added a call to `_possibleConstructorReturn` that was passed a var
+    // named `_this2` which was declared but isn't initialized until `super` runs
+    super(`Status ${error.status} returned from API request to ${url}`);
+    this.safeAssignProps(error);
+    this.name = 'ResponseError';
+
     // Check if it's a disconnection error or something else weird
     if (error.code && error.syscall) {
       return ResponseError.getSystemLevelError(error, url);
     }
-
-    super(`Status ${error.status} returned from API request to ${url}`);
-    Object.assign(this, error);
-
-    this.name = 'ResponseError';
   }
 
   static getSystemLevelError (error, url) {


### PR DESCRIPTION
There are two big fixes in this patch, the first is a
simple issue with readonly props. FakeError has readonly
`message` and `stack` properties that were overwitten with
calls to `Object.assign`. The fix is an alternative helper
that won't overrwrite those props.

The second fix is for a bug in babel. The ResponseError
constructor tries to bail out and return a different
FakeError subclass to differentiate Disconnection Errors.
Babel was inserting its guard function to ensure super was
called before the constructor exits (which we don't need
because we bail out explicitly).

This fixes an error in mweb 2X when we try to create a new `ResponseError` in `src/app/models/Session.js:fetchLogin`. You can add this to the `.end` call there to see it in action:

```js
  console.log('forcing response error', err, 'err has code?', err.code);
  const resultError = new ResponseError({
    message: 'connection refused',
    status: 500,
    syscall: true,
    code: 'ECONNREFUSED',
  }, '/loginproxy');

  console.log('result error is?', resultError);
  return reject(resultError);
```

Here's a babel repl 'gist' so you can see the babel compilation bug that this patch fixes in action [look at compiled code line 24](http://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=es2015%2Creact%2Cstage-2&code=class%20Foo%20%7B%0A%20%20constructor(thing)%20%7B%0A%20%20%20%20this.thing%20%3D%20thing%3B%0A%20%20%7D%0A%7D%0A%0Aclass%20Bar%20extends%20Foo%20%7B%0A%20%20constructor%20(thing%2C%20otherThing)%20%7B%0A%20%20%20%20if%20(otherThing)%20%7B%0A%20%20%20%20%20%20return%20new%20Baz()%3B%0A%20%20%20%20%7D%0A%20%20%20%20%0A%20%20%20%20super(thing)%3B%0A%20%20%7D%0A%7D%0A%0Aclass%20Baz%20extends%20Foo%20%7B%20%7D%0A%0A)

👓  @nramadas  @uzi 