### PR TITLE
Expose apiRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@r/api-client",
-  "version": "3.22.10",
+  "version": "3.23.0",
   "description": "A wrapper for Reddit's API",
   "main": "build.js",
   "scripts": {

--- a/src/index.es6.js
+++ b/src/index.es6.js
@@ -35,6 +35,7 @@ import { APIResponse, MergedApiReponse } from './apiBase/APIResponse';
 import Model from './apiBase/Model';
 import Record from './apiBase/Record';
 import * as ModelTypes from './models2/thingTypes';
+import apiRequest from './apiBase/apiRequest';
 
 import {
   withQueryAndResult,
@@ -191,6 +192,7 @@ export default makeOptions(DefaultOptions);
 
 export const requestUtils = {
   rawSend,
+  apiRequest,
 };
 
 export const optionsWithAuth = token => {


### PR DESCRIPTION
I forgot to expose this in the original patch and I'm using it in mweb.

:eyeglasses: @schwers || @nramadas 