### PR TITLE
Normalize model instances with default values

### DIFF
--- a/src/apiBase/Model.es6.js
+++ b/src/apiBase/Model.es6.js
@@ -101,6 +101,12 @@ export default class Model {
       }
     }
 
+    for (let propName in PROPERTIES) {
+      if (!this[propName]) {
+        this[propName] = PROPERTIES[propName]();
+      }
+    }
+
     const derivedKeys = Object.keys(DERIVED_PROPERTIES);
     for (let i = 0; i < derivedKeys.length; i++) {
       const derivedKey = derivedKeys[i];


### PR DESCRIPTION
Bug:
If a model is not built the same way on different api calls, then there
is a chance that expected fields are missing. For instance, when we
request comments via the comments page, we add the `loadMoreIds` field
manually since the data necessary to make this field exists in the
response. In the case of posting a reply, that same data is not there
since you get a singular reply back and therefore that field is not
added.

Since our store adds this incomplete reply to the comments state, this
can actually break views that expect the `loadMoreIds` field to be
there.

Fix:
This iterates through the model's `PROPERTIES` and adds any missing
fields with default values.

Testing:
I spot checked this across the mweb app and didn't experience any
problems.

:eyeglasses: @schwers || @nramadas 