### PR TITLE
Fix comment and post downvotes

### DIFF
--- a/src/apiBase/Model.es6.js
+++ b/src/apiBase/Model.es6.js
@@ -40,9 +40,15 @@ export default class Model {
     array: val => Array.isArray(val) ? val : [],
     arrayOf: (type=Model.Types.nop) => val => Model.Types.array(val).map(type),
     bool: val => Boolean(val),
-    cubit: val => {
-      const num = Number(val);
-      return num > 0 ? 1 : num < 0 ? -1 : 0;
+    likes: val => {
+      // coming from our api, these are booleans or null. Coming from
+      // our stub method, these are actual integers
+      switch (val) {
+        case true: return 1;
+        case false: return -1;
+        case null: return 0;
+        default: return val;
+      }
     },
 
     nop: val => val,
@@ -59,7 +65,7 @@ export default class Model {
     number: () => Math.floor(Math.random() * 100),
     array: () => Array.apply(null, Array(Math.floor(Math.random() * 10))),
     bool: () => Math.floor(Math.random() * 10) < 5,
-    cubit: () => Math.round((Math.random() * (1 - -1) + -1)),
+    likes: () => Math.round((Math.random() * (1 - -1) + -1)),
     nop: () => null,
   }
 
@@ -102,7 +108,7 @@ export default class Model {
     }
 
     for (let propName in PROPERTIES) {
-      if (!this[propName]) {
+      if (this[propName] === undefined) {
         this[propName] = PROPERTIES[propName]();
       }
     }

--- a/src/models2/CommentModel.es6.js
+++ b/src/models2/CommentModel.es6.js
@@ -22,7 +22,7 @@ export default class CommentModel extends RedditModel {
     edited: T.bool,
     gilded: T.number,
     id: T.string,
-    likes: T.cubit,
+    likes: T.likes,
     name: T.string,
     replies: T.array,
     numReplies: T.number,

--- a/src/models2/PostModel.es6.js
+++ b/src/models2/PostModel.es6.js
@@ -26,7 +26,7 @@ export default class PostModel extends RedditModel {
     hidden: T.bool,
     id: T.string,
     impPixel: T.string,
-    likes: T.cubit,
+    likes: T.likes,
     locked: T.bool,
     malink: T.link,
     media: T.nop,


### PR DESCRIPTION
Bug:
We get `true`, `false`, and `null` back from the api to represent upvote,
downvote, and no vote respectively. Currently the code is trying to
coerce `false` to -1. This doesn't work since it actually gets coerced to
0. So downvotes from the api were not being represented in the ui.

Fix:
Use a switch statement to normalize the api values to 1, 0, and -1. Also
name the validator `likes` since this is a super specific validator.

Additional changes:
There was an additional potential bug from a recent patch. Since the
api can return falsey values, we don't want to check for falseyness as
a way to determine if we need the fallback value. Although this happens
to work out currently, its ambiguity is probably dangerous.

The fix for this is to check explicitly for `undefined` since this
implies a missing key. Any other value value means it was explicitly set.

:eyeglasses: @schwers 