### PR TITLE
Model fixes

### DIFF
--- a/src/models2/Account.es6.js
+++ b/src/models2/Account.es6.js
@@ -33,7 +33,7 @@ export default class Subreddit extends RedditModel {
   }
 
   static API_ALIASES = {
-    comment_karm: 'commentKarma',
+    comment_karma: 'commentKarma',
     created_utc: 'createdUTC',
     gold_creddits: 'goldCreddits',
     gold_expiration: 'goldExpiration',

--- a/src/models2/Account.es6.js
+++ b/src/models2/Account.es6.js
@@ -42,6 +42,7 @@ export default class Subreddit extends RedditModel {
     has_verifified_email: 'hasVerifiedEmail',
     hide_from_robots: 'hideFromRobots',
     in_beta: 'inBeta',
+    inbox_count: 'inboxCount',
     is_employee: 'isEmployee',
     is_gold: 'isGold',
     is_mod: 'isMod',

--- a/src/models2/MessageModel.es6.js
+++ b/src/models2/MessageModel.es6.js
@@ -17,6 +17,7 @@ export default class Message extends RedditModel {
     replies: T.arrayOf(T.string),
     distinguished: T.string,
     subject: T.string,
+    new: T.bool,
 
     // derived
     cleanPermalink: T.link,


### PR DESCRIPTION
This fixes a bit of data that api-client sends back. Note that there should be a few more fixes for the mail stuff before this goes in:

1) We'll want to POST to [/api/read_message](https://www.reddit.com/dev/api/oauth#POST_api_read_message) ids of messages as we read them.  This can be done in reddit-mobile, but it might be better to do here in node-api-client in MessagesEndpoint.es6.js ... probably in the get() method when there's a specific thread we're fetching.
2) We'll want to update reddit-mobile's messaging views to highlight (or embolden) messages that are new.
3) We'll need some `badge` css styling for reddit-mobile in the `SettingsOverlayMenu` where we show `inboxCount`.

I consider this a WIP until those things are done as well.