### PR TITLE
Add queryParams to apiOptions

### DIFF
--- a/src/apiBase/APIRequestUtils.es6.js
+++ b/src/apiBase/APIRequestUtils.es6.js
@@ -81,7 +81,11 @@ export const rawSend = (apiOptions, method, path, data, type, cb) => {
 
   if (type === 'query') {
     data.app = appParameter(apiOptions);
-    s.query(data);
+    s.query({
+      ...(apiOptions.queryParams || {}),
+      ...data,
+      app: appParameter(apiOptions),
+    });
 
     if (s.redirects) {
       s.redirects(0);

--- a/src/apiBase/apiRequest.js
+++ b/src/apiBase/apiRequest.js
@@ -13,16 +13,20 @@ import ResponseError from './errors/ResponseError';
  */
 export default (apiOptions, method, path, options={}) => {
   const { query={}, body={}, type=null } = options;
-  const { origin, appName, env, token, headers={} } = apiOptions;
+  const { origin, appName, env, token, headers={}, queryParams={}, } = apiOptions;
 
   const _method = method.toLowerCase();
   const _headers = token
     ? { ...headers, Authorization: `Bearer ${token}` }
     : headers;
-  const _path = path.startsWith('/') ? path : `/${path}`
-  const _query = { ...query, app: `${appName}-${env}` };
-  const endpoint = origin + _path;
+  const _query = {
+    ...queryParams,
+    ...query,
+    app: `${appName}-${env}`,
+  };
 
+  const _path = path.startsWith('/') ? path : `/${path}`;
+  const endpoint = `${origin}${_path}`;
   const request = superagent[_method](endpoint).set(_headers).query(_query);
 
   if (type) {


### PR DESCRIPTION
APIOptions has a configurable headers field, clients use this
to add headers to api requests. This patch adds similiar functionality
but for queryParams.

👓  @curioussavage @nramadas 