### PR TITLE
Fix repl

### DIFF
--- a/repl
+++ b/repl
@@ -84,7 +84,7 @@ local.context.checkRecordForLoadMore = function checkRecordForLoadMore(r, record
 };
 
 function exportToContext(submoduleName) {
-  const submodule = require('./apiClient')[submoduleName];
+  const submodule = require('./build')[submoduleName];
   local.context[submoduleName] = submodule;
 
   Object.keys(submodule).forEach(function(subSubmoduleName) {


### PR DESCRIPTION
It looks like `apiClient.js` was replaced with `build.js` [here](https://github.com/reddit/node-api-client/commit/f9ff73a14b8858b91d7d1f4cc75a5402a53c195a), but this spot in `repl` wasn't updated.

👓 @schwers 