### PR TITLE
Modtools: Add distinguishType map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@r/api-client",
-  "version": "3.33.0",
+  "version": "3.33.1",
   "description": "A wrapper for Reddit's API",
   "main": "build.js",
   "scripts": {

--- a/src/apis/modTools.es6.js
+++ b/src/apis/modTools.es6.js
@@ -24,8 +24,14 @@ const approve = (apiOptions, fullname) => {
 
 const distinguish = (apiOptions, fullname, distinguishType) => {
   // Distinguish a link or comment
+
+  const distinguishTypeMap = {
+    'moderator': 'yes',
+    '': 'no',
+  };
+
   const body = {
-    how: distinguishType,
+    how: distinguishTypeMap[distinguishType],
     id: fullname,
   };
   return apiRequest(apiOptions, 'POST', 'api/distinguish', { body, type: 'form' });


### PR DESCRIPTION
👓 @birakattack @madbook 

Update: moved distinguishType mappings into node-api-client. Previously they were in the client, but this seems cleaner/better.