### PR TITLE
Add setStickyComment to api/modTools

### DIFF
--- a/src/apis/modTools.es6.js
+++ b/src/apis/modTools.es6.js
@@ -1,5 +1,11 @@
 import apiRequest from '../apiBase/apiRequest';
 
+/**
+ * Valid distinguish types.
+ * Note that the API endpoint used to distinguish posts and comments accepts
+ * 'yes' instead of 'moderator' and 'no' instead of ''.  See #distinguish
+ * @enum
+ */
 const DISTINGUISH_TYPES = {
   NONE: '',
   MODERATOR: 'moderator',
@@ -22,19 +28,46 @@ const approve = (apiOptions, fullname) => {
   return apiRequest(apiOptions, 'POST', 'api/approve', { body, type: 'form' });
 }
 
-const distinguish = (apiOptions, fullname, distinguishType) => {
-  // Distinguish a link or comment
-
+/**
+ * Distinguish a link or comment
+ * @function
+ * @param {Object} apiOptions
+ * @param {string} fullname The fullname of the target comment
+ * @param {DISTINGUISH_TYPES} distinguishType What type of distinguish is being set
+ * @param {?bool} [_sticky] For internal use by #setStickyComment
+ */
+const distinguish = (apiOptions, fullname, distinguishType, _sticky=null) => {
   const distinguishTypeMap = {
-    'moderator': 'yes',
-    '': 'no',
+    [DISTINGUISH_TYPES.MODERATOR]: 'yes',
+    [DISTINGUISH_TYPES.NONE]: 'no',
   };
 
   const body = {
-    how: distinguishTypeMap[distinguishType],
     id: fullname,
   };
-  return apiRequest(apiOptions, 'POST', 'api/distinguish', { body, type: 'form' });
+  const how = distinguishTypeMap[distinguishType] || distinguishType;
+
+  if (_sticky !== null) {
+    body.sticky = _sticky;
+  }
+
+  return apiRequest(apiOptions, 'POST', `api/distinguish/${how}`, { body, type: 'form' });
 }
 
-export default { remove, approve, distinguish, DISTINGUISH_TYPES }
+/**
+ * Sticky or unsticky a comment.
+ * Sticky comments are a special case of distinguished comments, and are done
+ * through the same API endpoint (api/distinguish).  That endpoint also handles
+ * distinguishing posts, but it does *not* handle sticky posts.  To avoid
+ * confusion, we'll keep sticky comments separated here.
+ * @function
+ * @param {Object} apiOptions
+ * @param {string} fullname The fullname of the target comment
+ * @param {boolean} isStickied Whether to sticky or unsticky the comment
+ */
+const setStickyComment = (apiOptions, fullname, isStickied) => {
+  const distinguishType = isStickied ? DISTINGUISH_TYPES.MODERATOR : DISTINGUISH_TYPES.NONE;
+  return distinguish(apiOptions, fullname, distinguishType, isStickied);
+};
+
+export default { remove, approve, distinguish, setStickyComment, DISTINGUISH_TYPES }


### PR DESCRIPTION
Enabled setting sticky comments.

The API for sticky comments is a little weird – it's actually an optional boolean flag sent to the distinguish endpoint used to distinguish comments and posts.   It only works for comments though (sticky posts have a separate API endpoint to handle some of their additional complexity).

I initially had trouble getting the distinguish API to work with the `sticky` flag.  I discovered that the `how` argument is actually meant to be [passed as part of the _path_](https://github.com/reddit/reddit-public/blob/master/r2/r2/config/routing.py#L427), rather than in the post body.  Moving it allows the call to work for both use cases.  I have _no idea_ why it works w/o the sticky flag (i.e. for normal distinguish/undistinguish calls).

👓 @scarow @birakattack 