### PR TITLE
Comments: make comments a flat list

### DIFF
--- a/src/apiBase/APIResponse.es6.js
+++ b/src/apiBase/APIResponse.es6.js
@@ -10,6 +10,8 @@ import {
   MESSAGE,
   SUBREDDIT,
   WIKI,
+  COMMENT_LOAD_MORE,
+  COMMENT_CONTINUE_THREAD,
 } from '../models2/thingTypes';
 
 export class APIResponseBase {
@@ -22,9 +24,13 @@ export class APIResponseBase {
     this.messages = {};
     this.subreddits = {};
     this.wikis = {};
+    this.continueThreadObjects = {};
+    this.commentLoadMoreObjects = {};
 
     this.typeToTable = {
       [COMMENT]: this.comments,
+      [COMMENT_LOAD_MORE]: this.commentLoadMoreObjects,
+      [COMMENT_CONTINUE_THREAD]: this.continueThreadObjects,
       [POST]: this.posts,
       [ACCOUNT]: this.accounts,
       [MESSAGE]: this.messages,

--- a/src/apiBase/Record.es6.js
+++ b/src/apiBase/Record.es6.js
@@ -5,3 +5,10 @@ export default class Record {
     this.paginationId = paginationId;
   }
 }
+
+export class DepthRecord extends Record {
+  constructor(type, uuid, paginationId=uuid, depth) {
+    super(type, uuid, paginationId);
+    this.depth = depth;
+  }
+}

--- a/src/apis/CommentsEndpoint.es6.js
+++ b/src/apis/CommentsEndpoint.es6.js
@@ -8,8 +8,7 @@ import PostModel from '../models2/PostModel';
 
 import {
   treeifyComments,
-  parseCommentData,
-  normalizeCommentReplies,
+  buildCommentsModels,
 } from '../lib/commentTreeUtils';
 
 const formatQuery = (query, method) => {
@@ -34,46 +33,35 @@ const getPath = (query) => {
   if (query.user) {
     return `user/${query.user}/comments.json`;
   } else if (query.commentIds) {
-    return `api/morechildren.json`;
+    return 'api/morechildren.json';
   } else {
     return `comments/${(query.id || query.linkId).replace(/^t3_/, '')}.json`;
   }
 };
 
-const parseGetBody = (apiResponse, hasChildren) => {
+const parseGetBody = (apiResponse /*, hasChildren */) => {
   const { body } = apiResponse.response;
-  let comments = [];
 
   if (Array.isArray(body)) {
     // The first part of the response is a link
-    const linkData = body[0].data;
-    if (linkData && linkData.children && linkData.children.length) {
-      linkData.children.forEach(link => {
+    const postData = body[0].data;
+    if (postData && postData.children && postData.children.length) {
+      postData.children.forEach(link => {
         apiResponse.addModel(PostModel.fromJSON(link.data));
       });
     }
 
-    comments = body[1].data.children.map(parseCommentData);
+    const comments = body[1].data.children;
+    buildCommentsModels(apiResponse, comments);
+
+  // handle loadMore result
   } else if (body.json && body.json.data) {
 
     const { things } = body.json.data;
-    comments = treeifyComments(things.map(parseCommentData));
+    const comments = treeifyComments(things);
+    buildCommentsModels(apiResponse, comments);
+
   }
-
-  normalizeCommentReplies(comments, true, (commentJSON, isTopLevel) => {
-    // parsing is done bottom up, comment models are immutable
-    // but they'll rely on the records
-    const comment = CommentModel.fromJSON(commentJSON);
-
-    if (isTopLevel) {
-      apiResponse.addResult(comment);
-    } else {
-      apiResponse.addModel(comment);
-    }
-
-    // this sets replies to be records for consistency
-    return comment.toRecord();
-  });
 
   return apiResponse;
 };

--- a/src/models2/CommentModel.es6.js
+++ b/src/models2/CommentModel.es6.js
@@ -1,5 +1,5 @@
 import RedditModel from './RedditModel';
-import Record from '../apiBase/Record';
+import { DepthRecord } from '../apiBase/Record';
 import { COMMENT, COMMENT_LOAD_MORE } from './thingTypes';
 
 import votable from './mixins/votable';
@@ -90,9 +90,10 @@ export default class CommentModel extends RedditModel {
   };
 
   toRecord() {
-    const record = new Record(this.type, this.uuid, this.paginationId);
-    record.depth = this.depth;
-    return record;
+    return new DepthRecord(this.type,
+                           this.uuid,
+                           this.paginationId,
+                           this.depth);
   }
 }
 

--- a/src/models2/CommentModel.es6.js
+++ b/src/models2/CommentModel.es6.js
@@ -26,8 +26,6 @@ export default class CommentModel extends RedditModel {
     name: T.string,
     replies: T.array,
     numReplies: T.number,
-    loadMore: T.bool,
-    loadMoreIds: T.arrayOf(T.string),
     saved: T.bool,
     score: T.number,
     stickied: T.bool,
@@ -36,6 +34,7 @@ export default class CommentModel extends RedditModel {
     removed: T.bool,
     approved: T.bool,
     spam: T.bool,
+    depth: T.number,
 
     // aliases
     approvedBy: T.string,
@@ -55,7 +54,6 @@ export default class CommentModel extends RedditModel {
 
     // derived
     cleanPermalink: T.link,
-    canContinueThread: T.bool,
   };
 
   static API_ALIASES = {
@@ -89,30 +87,12 @@ export default class CommentModel extends RedditModel {
 
       return `/r/${subreddit}/comments/${link_id.substr(3)}/comment/${id}`;
     },
-
-    canContinueThread(data) {
-      // We derive this property to make the logic for rendering loadMore and
-      // continue thread more explicit
-      return data.loadMore && data.loadMoreIds.length === 0; 
-    },  
-   };
-
-  makeUUID(data) {
-    if (data.name === 't1__' && data.parent_id) {
-      // This is a stub for load more, parentId is needed to fetch more
-      return data.parent_id;
-    }
-
-    return data.name;
-  }
+  };
 
   toRecord() {
-    if (this.uuid === this.name) {
-      return super.toRecord();
-    }
-
-    // otherwise its a load more stub for super nested comments
-    return new Record(COMMENT_LOAD_MORE, this.parentId);
+    const record = new Record(this.type, this.uuid, this.paginationId);
+    record.depth = this.depth;
+    return record;
   }
 }
 

--- a/src/models2/ContinueModel.es6.js
+++ b/src/models2/ContinueModel.es6.js
@@ -1,5 +1,5 @@
 import RedditModel from './RedditModel';
-import Record from '../apiBase/Record';
+import { DepthRecord } from '../apiBase/Record';
 
 import { COMMENT_CONTINUE_THREAD } from './thingTypes';
 
@@ -19,12 +19,13 @@ export default class ContinueThreadModel extends RedditModel {
   }
 
   makeUUID() {
-    return (Math.random() * 16).toFixed();
+    return `${this.parentId}-${COMMENT_CONTINUE_THREAD}`;
   }
 
   toRecord() {
-    const record = new Record(this.type, this.uuid, this.paginationId);
-    record.depth = this.depth;
-    return record;
+    return new DepthRecord(this.type,
+                           this.uuid,
+                           this.paginationId,
+                           this.depth);
   }
 }

--- a/src/models2/ContinueModel.es6.js
+++ b/src/models2/ContinueModel.es6.js
@@ -1,0 +1,30 @@
+import RedditModel from './RedditModel';
+import Record from '../apiBase/Record';
+
+import { COMMENT_CONTINUE_THREAD } from './thingTypes';
+
+const T = RedditModel.Types;
+
+export default class ContinueThreadModel extends RedditModel {
+  static type = COMMENT_CONTINUE_THREAD;
+
+  static PROPERTIES = {
+    parentId: T.string,
+    id: T.string,
+    depth: T.number,
+  }
+
+  static API_ALIASES = {
+    parent_id: 'parentId',
+  }
+
+  makeUUID() {
+    return (Math.random() * 16).toFixed();
+  }
+
+  toRecord() {
+    const record = new Record(this.type, this.uuid, this.paginationId);
+    record.depth = this.depth;
+    return record;
+  }
+}

--- a/src/models2/LoadMoreModel.es6.js
+++ b/src/models2/LoadMoreModel.es6.js
@@ -1,5 +1,5 @@
 import RedditModel from './RedditModel';
-import Record from '../apiBase/Record';
+import { DepthRecord } from '../apiBase/Record';
 
 import { COMMENT_LOAD_MORE } from './thingTypes';
 
@@ -19,9 +19,14 @@ export default class LoadMoreModel extends RedditModel {
     parent_id: 'parentId',
   }
 
+  makeUUID() {
+    return `${this.parentId}-${COMMENT_LOAD_MORE}`;
+  }
+
   toRecord() {
-    const record = new Record(this.type, this.uuid, this.paginationId);
-    record.depth = this.depth;
-    return record;
+    return new DepthRecord(this.type,
+                           this.uuid,
+                           this.paginationId,
+                           this.depth);
   }
 }

--- a/src/models2/LoadMoreModel.es6.js
+++ b/src/models2/LoadMoreModel.es6.js
@@ -1,0 +1,27 @@
+import RedditModel from './RedditModel';
+import Record from '../apiBase/Record';
+
+import { COMMENT_LOAD_MORE } from './thingTypes';
+
+const T = RedditModel.Types;
+
+export default class LoadMoreModel extends RedditModel {
+  static type = COMMENT_LOAD_MORE;
+
+  static PROPERTIES = {
+    parentId: T.string,
+    children: T.arrayOf(T.string),
+    count: T.number,
+    depth: T.number,
+  }
+
+  static API_ALIASES = {
+    parent_id: 'parentId',
+  }
+
+  toRecord() {
+    const record = new Record(this.type, this.uuid, this.paginationId);
+    record.depth = this.depth;
+    return record;
+  }
+}

--- a/src/models2/thingTypes.es6.js
+++ b/src/models2/thingTypes.es6.js
@@ -1,6 +1,7 @@
 export const COMMENT = 'comment';
 export const COMMENT_TYPE = 't1';
 export const COMMENT_LOAD_MORE = 'comment_load_more';
+export const COMMENT_CONTINUE_THREAD = 'comment_continue_thread';
 
 export const ACCOUNT = 'account';
 export const ACCOUNT_TYPE = 't2';


### PR DESCRIPTION
To enable this I had to make new models for load more and continue thread fake comments.
These are now left in the flat list instead of using flags/data on the parent
to know when to show them. I tried to optimize the methods for processing
comment results. Worst case would be for loadMore responses we have to iterate through
the list twice to build the tree (to get depth more easily) then we iterate and walk
the comment trees once to build the instantiate the models, build the
flat list of comment stubs and create the dictionary of <comment id> =>
<comment data>.